### PR TITLE
chore: added a comment to change OTel endpoint to EU instance in collector_configs/otelcol-config.yaml

### DIFF
--- a/collector_configs/otelcol-config.yaml
+++ b/collector_configs/otelcol-config.yaml
@@ -1,13 +1,10 @@
 exporters:
   otlp:
-    endpoint: api.honeycomb.io:443
+    endpoint: api.honeycomb.io:443 # or api.eu1.honeycomb.io:443 for EU teams 
     headers:
       x-honeycomb-team: "${HONEYCOMB_API_KEY}"
   debug:
     verbosity: detailed
-
-# The default endpoint references `api.honeycomb.io:443`. If you are in the EU, set the endpoint to `api.eu1.honeycomb.io:443`.
-
 processors:
   memory_limiter:
     check_interval: 5s

--- a/collector_configs/otelcol-config.yaml
+++ b/collector_configs/otelcol-config.yaml
@@ -6,7 +6,7 @@ exporters:
   debug:
     verbosity: detailed
 
-# The default OpenTelemetry endpoint references `api.honeycomb.io:443`. If you are in the EU, set the endpoint to `api.eu1.honeycomb.io:443`.
+# The default endpoint references `api.honeycomb.io:443`. If you are in the EU, set the endpoint to `api.eu1.honeycomb.io:443`.
 
 processors:
   memory_limiter:

--- a/collector_configs/otelcol-config.yaml
+++ b/collector_configs/otelcol-config.yaml
@@ -6,6 +6,8 @@ exporters:
   debug:
     verbosity: detailed
 
+# The default OpenTelemetry endpoint references `api.honeycomb.io:443`. If you are in the EU, set the endpoint to `api.eu1.honeycomb.io:443`.
+
 processors:
   memory_limiter:
     check_interval: 5s


### PR DESCRIPTION
## Which problem is this PR solving?
A customer gave us feedback on the Academy course on Refinery and noted that the app doesn't run and the course content doesn't instruct properly for EU Refinery users. The OTel endpoint referenced would need to be revised by the user since the default is the US endpoint. 

## Short description of the changes
There is a comment in `collector_configs/otelcol-config.yaml` that explains this for users and instructs them to change it to `api.eu1.honeycomb.io:443`.
