### PR TITLE
chore: added a comment for EU users to add explicit line to route to EU endpoint in refinery_configs/config.yaml

### DIFF
--- a/refinery_configs/config.yaml
+++ b/refinery_configs/config.yaml
@@ -4,9 +4,7 @@ General:
 Network:
   ListenAddr: "0.0.0.0:8080"
   PeerListenAddr: "0.0.0.0:8081"
-  # The default causes Refinery to point to the US endpoint upon instantiation.
-  # If you are in the EU, add the line below.
-  # HoneycombAPI: "https://api.eu1.honeycomb.io"
+  # For EU teams, add HoneycombAPI: "https://api.eu1.honeycomb.io"
 GRPCServerParameters:
   Enabled: true
   ListenAddr: "0.0.0.0:9090"

--- a/refinery_configs/config.yaml
+++ b/refinery_configs/config.yaml
@@ -4,6 +4,9 @@ General:
 Network:
   ListenAddr: "0.0.0.0:8080"
   PeerListenAddr: "0.0.0.0:8081"
+  # The default causes Refinery to point to the US endpoint upon instantiation.
+  # If you are in the EU, add the line below.
+  # HoneycombAPI: "https://api.eu1.honeycomb.io"
 GRPCServerParameters:
   Enabled: true
   ListenAddr: "0.0.0.0:9090"


### PR DESCRIPTION
## Which problem is this PR solving?
A customer gave us feedback on the Academy course on Refinery and noted that the app doesn't run and the course content doesn't instruct properly for EU Refinery users. The EU user would need to add an explicit `HoneycombAPI: "https://api.eu1.honeycomb.io/"` under `Network` in `refinery_configs/config.yaml`. 

## Short description of the changes
There is a comment in `refinery_configs/config.yaml` that instructs EU users to add that explicit line.
